### PR TITLE
Persist selected render mode with mesh highlight

### DIFF
--- a/src/editor/editor.h
+++ b/src/editor/editor.h
@@ -167,6 +167,9 @@ class Editor {
   gfx::rhi::RenderingApi m_pendingApi;
 
   std::function<Window*(gfx::rhi::RenderingApi)> m_windowRecreationCallback;
+
+  // Render mode preservation setting
+  bool m_preserveRenderModeOnSelection = false;
 };
 
 }  // namespace arise


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add option to preserve render mode when selecting entities to allow consistent visualization.

---
<a href="https://cursor.com/background-agent?bcId=bc-e3442afe-8984-4785-9242-ce9358af8c1f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e3442afe-8984-4785-9242-ce9358af8c1f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>