### PR TITLE
Check usage of m_mappedData_ for buffers

### DIFF
--- a/src/gfx/rhi/backends/dx12/buffer_dx12.h
+++ b/src/gfx/rhi/backends/dx12/buffer_dx12.h
@@ -34,10 +34,6 @@ class BufferDx12 : public Buffer {
 
   void updateCurrentState(D3D12_RESOURCE_STATES newState) { m_currentState_ = newState; }
 
-  bool isMapped() const { return m_isMapped_; }
-
-  void* getMappedData() const { return m_mappedData_; }
-
   D3D12MA::Allocation* getAllocation() const { return m_allocation_.Get(); }
 
   protected:

--- a/src/gfx/rhi/backends/vulkan/buffer_vk.h
+++ b/src/gfx/rhi/backends/vulkan/buffer_vk.h
@@ -23,10 +23,6 @@ class BufferVk : public Buffer {
 
   uint32_t getStride() const { return m_stride_; }
 
-  bool isMapped() const { return m_isMapped_; }
-
-  void* getMappedData() const { return m_mappedData_; }
-
   private:
   friend class DeviceVk;
   // update_ method is called from DeviceVk


### PR DESCRIPTION
Remove unused `isMapped()` and `getMappedData()` methods to improve encapsulation and simplify the API.

---
<a href="https://cursor.com/background-agent?bcId=bc-8e57946b-5d1c-48b8-8764-44f7617bf038">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8e57946b-5d1c-48b8-8764-44f7617bf038">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>